### PR TITLE
phpunit/php-code-coverage update (from ~2.0 to ~4.0||~5.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
-    - php: 5.4
-    - php: 5.5
     - php: 5.6
     - php: 5.6
       env: deps=low

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.x-dev] - UNRELEASED
+
+- Update PHP requirement to `>=5.6` (from `>=5.3.10`)
+- Update `phpunit/php-code-coverage` from `~2.2` to `~4.0||~5.0`.
+- Add/implement missing tests for Xml and Crap4j reporters
+- Mark `phpdbg` or `xdebug` specific tests so they are skipped automatically
+  (using phpunit's @requires).
+
 ## [3.0.0] - 2017-04-08 (backported `3.0.x-dev` + patches)
 
 - Fixed compatibility with Symfony `2.x` and `3.x` #2

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ compatible version numbers for stable releases.
 
 ## Requirements
 
-- PHP 5.3.10+ / 7.0+
+- PHP 5.6+ / 7.0+
 - [Behat v3][3]
 - [Xdebug][5] or [phpdbg][6] extension enabled (PHP 7+ is required for code
   generation to work with [phpdbg][6]).

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": ">=5.3.10",
-        "phpunit/php-code-coverage": "2.2.*",
+        "phpunit/php-code-coverage": "~4.0||~5.0",
         "behat/behat": "~3.0",
         "guzzlehttp/guzzle": "~3.0",
         "symfony/config": "~2.3||~3.0",
@@ -36,7 +36,7 @@
         "symfony/http-foundation": "~2.3||~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~5.0",
         "mikey179/vfsStream": "1.3.*"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://github.com/leanphp/behat-code-coverage#behat-code-coverage"
     },
     "require": {
-        "php": ">=5.3.10",
+        "php": ">=5.6",
         "phpunit/php-code-coverage": "~4.0||~5.0",
         "behat/behat": "~3.0",
         "guzzlehttp/guzzle": "~3.0",

--- a/src/Common/Driver/Factory.php
+++ b/src/Common/Driver/Factory.php
@@ -8,7 +8,7 @@
 
 namespace LeanPHP\Behat\CodeCoverage\Common\Driver;
 
-use PHP_CodeCoverage_Driver as DriverInterface;
+use SebastianBergmann\CodeCoverage\Driver\Driver as DriverInterface;
 
 /**
  * Driver factory

--- a/src/Common/Driver/HHVM.php
+++ b/src/Common/Driver/HHVM.php
@@ -8,7 +8,8 @@
 
 namespace LeanPHP\Behat\CodeCoverage\Common\Driver;
 
-use PHP_CodeCoverage_Driver as DriverInterface;
+use SebastianBergmann\CodeCoverage\Driver\Driver as DriverInterface;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
 
 /**
  * HHVM (Hip Hop VM) Driver
@@ -22,19 +23,19 @@ class HHVM implements DriverInterface
     /**
      * Constructor
      *
-     * @throws \PHP_CodeCoverage_Exception if PHP code coverage not enabled
+     * @throws SebastianBergmann\CodeCoverage\Exception if PHP code coverage not enabled
      */
     public function __construct()
     {
         if ( ! defined('HPHP_VERSION')) {
-            throw new \PHP_CodeCoverage_Exception('This driver requires HHVM');
+            throw new \SebastianBergmann\CodeCoverage\Exception('This driver requires HHVM');
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function start()
+    public function start($determineUnusedAndDead = true)
     {
         fb_enable_code_coverage();
     }

--- a/src/Common/Driver/HHVM.php
+++ b/src/Common/Driver/HHVM.php
@@ -9,12 +9,12 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Driver;
 
 use SebastianBergmann\CodeCoverage\Driver\Driver as DriverInterface;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 
 /**
  * HHVM (Hip Hop VM) Driver
  *
- * {@internal Derived from PHP_CodeCoverage_Driver_Xdebug.}
+ * {@internal Derived from SebastianBergmann\CodeCoverage\Driver\Xdebug.}
  *
  * @author Anthon Pang <apang@softwaredevelopment.ca>
  */

--- a/src/Common/Driver/HHVM.php
+++ b/src/Common/Driver/HHVM.php
@@ -23,12 +23,12 @@ class HHVM implements DriverInterface
     /**
      * Constructor
      *
-     * @throws SebastianBergmann\CodeCoverage\Exception if PHP code coverage not enabled
+     * @throws SebastianBergmann\CodeCoverage\RuntimeException if PHP code coverage not enabled
      */
     public function __construct()
     {
         if ( ! defined('HPHP_VERSION')) {
-            throw new \SebastianBergmann\CodeCoverage\Exception('This driver requires HHVM');
+            throw new \SebastianBergmann\CodeCoverage\RuntimeException('This driver requires HHVM');
         }
     }
 

--- a/src/Common/Driver/Stub.php
+++ b/src/Common/Driver/Stub.php
@@ -8,7 +8,7 @@
 
 namespace LeanPHP\Behat\CodeCoverage\Common\Driver;
 
-use PHP_CodeCoverage_Driver as DriverInterface;
+use SebastianBergmann\CodeCoverage\Driver\Driver as DriverInterface;
 
 /**
  * Stub driver
@@ -42,7 +42,7 @@ class Stub implements DriverInterface
     /**
      * {@inheritdoc}
      */
-    public function start()
+    public function start($determineUnusedAndDead = true)
     {
         if ($this->driver) {
             $this->driver->start();

--- a/src/Common/Driver/XCache.php
+++ b/src/Common/Driver/XCache.php
@@ -13,7 +13,7 @@ use SebastianBergmann\CodeCoverage\Driver\Driver as DriverInterface;
 /**
  * XCache Driver
  *
- * {@internal Derived from PHP_CodeCoverage_Driver_Xdebug.}
+ * {@internal Derived from SebastianBergmann\CodeCoverage\Driver\Xdebug.}
  *
  * @author Anthon Pang <apang@softwaredevelopment.ca>
  */
@@ -33,7 +33,7 @@ class XCache implements DriverInterface
         if (version_compare(phpversion('xcache'), '1.2.0', '<') ||
             ! ini_get('xcache.coverager')
         ) {
-            throw new \PHP_CodeCoverage_Exception('xcache.coverager=On has to be set in php.ini');
+            throw new \SebastianBergmann\CodeCoverage\RuntimeException('xcache.coverager=On has to be set in php.ini');
         }
     }
 

--- a/src/Common/Driver/XCache.php
+++ b/src/Common/Driver/XCache.php
@@ -22,12 +22,12 @@ class XCache implements DriverInterface
     /**
      * Constructor
      *
-     * @throws \PHP_CodeCoverage_Exception if PHP code coverage not enabled
+     * @throws \SebastianBergmann\CodeCoverage\RuntimeException if PHP code coverage not enabled
      */
     public function __construct()
     {
         if ( ! extension_loaded('xcache')) {
-            throw new \SebastianBergmann\CodeCoverage\Exception('This driver requires XCache');
+            throw new \SebastianBergmann\CodeCoverage\RuntimeException('This driver requires XCache');
         }
 
         if (version_compare(phpversion('xcache'), '1.2.0', '<') ||

--- a/src/Common/Driver/XCache.php
+++ b/src/Common/Driver/XCache.php
@@ -8,7 +8,7 @@
 
 namespace LeanPHP\Behat\CodeCoverage\Common\Driver;
 
-use PHP_CodeCoverage_Driver as DriverInterface;
+use SebastianBergmann\CodeCoverage\Driver\Driver as DriverInterface;
 
 /**
  * XCache Driver
@@ -27,7 +27,7 @@ class XCache implements DriverInterface
     public function __construct()
     {
         if ( ! extension_loaded('xcache')) {
-            throw new \PHP_CodeCoverage_Exception('This driver requires XCache');
+            throw new \SebastianBergmann\CodeCoverage\Exception('This driver requires XCache');
         }
 
         if (version_compare(phpversion('xcache'), '1.2.0', '<') ||
@@ -40,7 +40,7 @@ class XCache implements DriverInterface
     /**
      * {@inheritdoc}
      */
-    public function start()
+    public function start($determineUnusedAndDead = true)
     {
         xcache_coverager_start();
     }

--- a/src/Common/Report/Clover.php
+++ b/src/Common/Report/Clover.php
@@ -9,7 +9,7 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Clover as CloverCC;
 
 /**
@@ -49,7 +49,7 @@ class Clover implements ReportInterface
     /**
      * {@inheritdoc}
      */
-    public function process(PHP_CodeCoverage $coverage)
+    public function process(CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/Report/Clover.php
+++ b/src/Common/Report/Clover.php
@@ -9,6 +9,8 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\Clover as CloverCC;
 
 /**
  * Clover report
@@ -18,7 +20,7 @@ use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 class Clover implements ReportInterface
 {
     /**
-     * @var \PHP_CodeCoverage_Report_Clover
+     * @var \SebastianBergmann\CodeCoverage\Report\Clover
      */
     private $report;
 
@@ -40,14 +42,14 @@ class Clover implements ReportInterface
             $options['name'] = null;
         }
 
-        $this->report = new \PHP_CodeCoverage_Report_Clover();
+        $this->report = new CloverCC();
         $this->options = $options;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function process(\PHP_CodeCoverage $coverage)
+    public function process(PHP_CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/Report/Clover.php
+++ b/src/Common/Report/Clover.php
@@ -10,7 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use SebastianBergmann\CodeCoverage\Report\Clover as CloverCC;
+use SebastianBergmann\CodeCoverage\Report\Clover as CloverReport;
 
 /**
  * Clover report
@@ -42,7 +42,7 @@ class Clover implements ReportInterface
             $options['name'] = null;
         }
 
-        $this->report = new CloverCC();
+        $this->report = new CloverReport();
         $this->options = $options;
     }
 

--- a/src/Common/Report/Crap4j.php
+++ b/src/Common/Report/Crap4j.php
@@ -10,7 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use SebastianBergmann\CodeCoverage\Report\Crap4j as Crap4jCC;
+use SebastianBergmann\CodeCoverage\Report\Crap4j as Crap4jReport;
 /**
  * Crap4j report
  *
@@ -19,7 +19,7 @@ use SebastianBergmann\CodeCoverage\Report\Crap4j as Crap4jCC;
 class Crap4j implements ReportInterface
 {
     /**
-     * @var Crap4jCC
+     * @var SebastianBergmann\CodeCoverage\Report\Crap4j
      */
     private $report;
 
@@ -33,7 +33,7 @@ class Crap4j implements ReportInterface
      */
     public function __construct(array $options)
     {
-        if ( ! class_exists('Crap4jCC')) {
+        if ( ! class_exists('SebastianBergmann\CodeCoverage\Report\Crap4j')) {
             throw new \Exception('Crap4j requires CodeCoverage 4.0+');
         }
 
@@ -45,7 +45,7 @@ class Crap4j implements ReportInterface
             $options['name'] = null;
         }
 
-        $this->report = new Crap4jCC();
+        $this->report = new Crap4jReport();
         $this->options = $options;
     }
 

--- a/src/Common/Report/Crap4j.php
+++ b/src/Common/Report/Crap4j.php
@@ -9,7 +9,7 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Crap4j as Crap4jCC;
 /**
  * Crap4j report
@@ -34,7 +34,7 @@ class Crap4j implements ReportInterface
     public function __construct(array $options)
     {
         if ( ! class_exists('Crap4jCC')) {
-            throw new \Exception('Crap4j requires PHP_CodeCoverage 4.0+');
+            throw new \Exception('Crap4j requires CodeCoverage 4.0+');
         }
 
         if ( ! isset($options['target'])) {
@@ -52,7 +52,7 @@ class Crap4j implements ReportInterface
     /**
      * {@inheritdoc}
      */
-    public function process(PHP_CodeCoverage $coverage)
+    public function process(CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/Report/Crap4j.php
+++ b/src/Common/Report/Crap4j.php
@@ -9,7 +9,8 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
-
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\Crap4j as Crap4jCC;
 /**
  * Crap4j report
  *
@@ -18,7 +19,7 @@ use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 class Crap4j implements ReportInterface
 {
     /**
-     * @var \PHP_CodeCoverage_Report_Crap4j
+     * @var Crap4jCC
      */
     private $report;
 
@@ -32,8 +33,8 @@ class Crap4j implements ReportInterface
      */
     public function __construct(array $options)
     {
-        if ( ! class_exists('\PHP_CodeCoverage_Report_Crap4j')) {
-            throw new \Exception('Crap4j requires PHP_CodeCoverage 1.3+');
+        if ( ! class_exists('Crap4jCC')) {
+            throw new \Exception('Crap4j requires PHP_CodeCoverage 4.0+');
         }
 
         if ( ! isset($options['target'])) {
@@ -44,14 +45,14 @@ class Crap4j implements ReportInterface
             $options['name'] = null;
         }
 
-        $this->report = new \PHP_CodeCoverage_Report_Crap4j();
+        $this->report = new Crap4jCC();
         $this->options = $options;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function process(\PHP_CodeCoverage $coverage)
+    public function process(PHP_CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/Report/Html.php
+++ b/src/Common/Report/Html.php
@@ -9,7 +9,7 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\HTML as HTMLCC;
 
 /**
@@ -72,7 +72,7 @@ class Html implements ReportInterface
     /**
      * {@inheritdoc}
      */
-    public function process(PHP_CodeCoverage $coverage)
+    public function process(CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/Report/Html.php
+++ b/src/Common/Report/Html.php
@@ -9,6 +9,8 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\HTML as HTMLCC;
 
 /**
  * HTML report
@@ -18,7 +20,7 @@ use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 class Html implements ReportInterface
 {
     /**
-     * @var \PHP_CodeCoverage_Report_HTML
+     * @var HTMLCC
      */
     private $report;
 
@@ -56,7 +58,7 @@ class Html implements ReportInterface
             $options['generator'] = '';
         }
 
-        $this->report = new \PHP_CodeCoverage_Report_HTML(
+        $this->report = new HTMLCC(
             $options['charset'],
             $options['highlight'],
             $options['lowUpperBound'],
@@ -70,7 +72,7 @@ class Html implements ReportInterface
     /**
      * {@inheritdoc}
      */
-    public function process(\PHP_CodeCoverage $coverage)
+    public function process(PHP_CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/Report/Html.php
+++ b/src/Common/Report/Html.php
@@ -10,7 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use SebastianBergmann\CodeCoverage\Report\HTML as HTMLCC;
+use SebastianBergmann\CodeCoverage\Report\Html\Facade;
 
 /**
  * HTML report
@@ -20,7 +20,7 @@ use SebastianBergmann\CodeCoverage\Report\HTML as HTMLCC;
 class Html implements ReportInterface
 {
     /**
-     * @var HTMLCC
+     * @var Facade
      */
     private $report;
 
@@ -58,9 +58,7 @@ class Html implements ReportInterface
             $options['generator'] = '';
         }
 
-        $this->report = new HTMLCC(
-            $options['charset'],
-            $options['highlight'],
+        $this->report = new Facade(
             $options['lowUpperBound'],
             $options['highUpperBound'],
             $options['generator']

--- a/src/Common/Report/Php.php
+++ b/src/Common/Report/Php.php
@@ -10,8 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use SebastianBergmann\CodeCoverage\Report\Clover as Clover;
-use SebastianBergmann\CodeCoverage\Report\PHP as PHPCC;
+use SebastianBergmann\CodeCoverage\Report\PHP as PHPReport;
 
 /**
  * PHP report
@@ -39,7 +38,7 @@ class Php implements ReportInterface
             $options['target'] = null;
         }
 
-        $this->report = new PHPCC();
+        $this->report = new PHPReport();
         $this->options = $options;
     }
 

--- a/src/Common/Report/Php.php
+++ b/src/Common/Report/Php.php
@@ -9,6 +9,9 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\Clover as Clover;
+use SebastianBergmann\CodeCoverage\Report\PHP as PHPCC;
 
 /**
  * PHP report
@@ -18,7 +21,7 @@ use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 class Php implements ReportInterface
 {
     /**
-     * @var \PHP_CodeCoverage_Report_Clover
+     * @var \SebastianBergmann\CodeCoverage\Report\Clover
      */
     private $report;
 
@@ -36,14 +39,14 @@ class Php implements ReportInterface
             $options['target'] = null;
         }
 
-        $this->report = new \PHP_CodeCoverage_Report_PHP();
+        $this->report = new PHPCC();
         $this->options = $options;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function process(\PHP_CodeCoverage $coverage)
+    public function process(PHP_CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/Report/Php.php
+++ b/src/Common/Report/Php.php
@@ -9,7 +9,7 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Clover as Clover;
 use SebastianBergmann\CodeCoverage\Report\PHP as PHPCC;
 
@@ -46,7 +46,7 @@ class Php implements ReportInterface
     /**
      * {@inheritdoc}
      */
-    public function process(PHP_CodeCoverage $coverage)
+    public function process(CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/Report/Text.php
+++ b/src/Common/Report/Text.php
@@ -10,7 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use SebastianBergmann\CodeCoverage\Report\Text as TextCC;
+use SebastianBergmann\CodeCoverage\Report\Text as TextReport;
 
 /**
  * Text report
@@ -57,7 +57,7 @@ class Text implements ReportInterface
         if ($this->getVersion() === '1.2') {
             $outputStream = new \PHPUnit_Util_Printer($options['printer']);
 
-            $this->report = new TextCC(
+            $this->report = new TextReport(
                 $outputStream,
                 $options['lowUpperBound'],
                 $options['highUpperBound'],
@@ -68,7 +68,7 @@ class Text implements ReportInterface
                 $options['showOnlySummary'] = false;
             }
 
-            $this->report = new TextCC(
+            $this->report = new TextReport(
                 $options['lowUpperBound'],
                 $options['highUpperBound'],
                 $options['showUncoveredFiles'],

--- a/src/Common/Report/Text.php
+++ b/src/Common/Report/Text.php
@@ -9,6 +9,8 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\Text as TextCC;
 
 /**
  * Text report
@@ -18,7 +20,7 @@ use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 class Text implements ReportInterface
 {
     /**
-     * @var \PHP_CodeCoverage_Report_Text
+     * @var \SebastianBergmann\CodeCoverage\Report\Text
      */
     private $report;
 
@@ -55,7 +57,7 @@ class Text implements ReportInterface
         if ($this->getVersion() === '1.2') {
             $outputStream = new \PHPUnit_Util_Printer($options['printer']);
 
-            $this->report = new \PHP_CodeCoverage_Report_Text(
+            $this->report = new TextCC(
                 $outputStream,
                 $options['lowUpperBound'],
                 $options['highUpperBound'],
@@ -66,7 +68,7 @@ class Text implements ReportInterface
                 $options['showOnlySummary'] = false;
             }
 
-            $this->report = new \PHP_CodeCoverage_Report_Text(
+            $this->report = new TextCC(
                 $options['lowUpperBound'],
                 $options['highUpperBound'],
                 $options['showUncoveredFiles'],
@@ -80,7 +82,7 @@ class Text implements ReportInterface
     /**
      * {@inheritdoc}
      */
-    public function process(\PHP_CodeCoverage $coverage)
+    public function process(PHP_CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,
@@ -90,7 +92,7 @@ class Text implements ReportInterface
 
     private function getVersion()
     {
-        $reflectionMethod = new \ReflectionMethod('PHP_CodeCoverage_Report_Text', '__construct');
+        $reflectionMethod = new \ReflectionMethod('TextCC', '__construct');
         $parameters = $reflectionMethod->getParameters();
 
         if (reset($parameters)->name === 'outputStream') {

--- a/src/Common/Report/Text.php
+++ b/src/Common/Report/Text.php
@@ -92,7 +92,7 @@ class Text implements ReportInterface
 
     private function getVersion()
     {
-        $reflectionMethod = new \ReflectionMethod('TextCC', '__construct');
+        $reflectionMethod = new \ReflectionMethod('SebastianBergmann\CodeCoverage\Report\Text', '__construct');
         $parameters = $reflectionMethod->getParameters();
 
         if (reset($parameters)->name === 'outputStream') {

--- a/src/Common/Report/Text.php
+++ b/src/Common/Report/Text.php
@@ -9,7 +9,7 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Text as TextCC;
 
 /**
@@ -82,7 +82,7 @@ class Text implements ReportInterface
     /**
      * {@inheritdoc}
      */
-    public function process(PHP_CodeCoverage $coverage)
+    public function process(CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/Report/Xml.php
+++ b/src/Common/Report/Xml.php
@@ -9,7 +9,7 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\XML as XMLCC;
 
 /**
@@ -35,7 +35,7 @@ class Xml implements ReportInterface
     public function __construct(array $options)
     {
         if ( ! class_exists('XMLCC')) {
-            throw new \Exception('XML requires PHP_CodeCoverage 4.0+');
+            throw new \Exception('XML requires CodeCoverage 4.0+');
         }
 
         if ( ! isset($options['target'])) {
@@ -49,7 +49,7 @@ class Xml implements ReportInterface
     /**
      * {@inheritdoc}
      */
-    public function process(PHP_CodeCoverage $coverage)
+    public function process(CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/Report/Xml.php
+++ b/src/Common/Report/Xml.php
@@ -10,7 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use SebastianBergmann\CodeCoverage\Report\XML as XMLCC;
+use SebastianBergmann\CodeCoverage\Report\Xml\Facade;;
 
 /**
  * XML report
@@ -34,7 +34,7 @@ class Xml implements ReportInterface
      */
     public function __construct(array $options)
     {
-        if ( ! class_exists('XMLCC')) {
+        if ( ! class_exists('SebastianBergmann\CodeCoverage\Report\Xml\Facade')) {
             throw new \Exception('XML requires CodeCoverage 4.0+');
         }
 
@@ -42,7 +42,7 @@ class Xml implements ReportInterface
             $options['target'] = null;
         }
 
-        $this->report = new XMLCC();
+        $this->report = new Facade(array());
         $this->options = $options;
     }
 

--- a/src/Common/Report/Xml.php
+++ b/src/Common/Report/Xml.php
@@ -9,6 +9,8 @@
 namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\XML as XMLCC;
 
 /**
  * XML report
@@ -18,7 +20,7 @@ use LeanPHP\Behat\CodeCoverage\Common\ReportInterface;
 class Xml implements ReportInterface
 {
     /**
-     * @var \PHP_CodeCoverage_Report_XML
+     * @var \SebastianBergmann\CodeCoverage\Report\XML
      */
     private $report;
 
@@ -32,22 +34,22 @@ class Xml implements ReportInterface
      */
     public function __construct(array $options)
     {
-        if ( ! class_exists('\PHP_CodeCoverage_Report_Xml')) {
-            throw new \Exception('XML requires PHP_CodeCoverage 1.3+');
+        if ( ! class_exists('XMLCC')) {
+            throw new \Exception('XML requires PHP_CodeCoverage 4.0+');
         }
 
         if ( ! isset($options['target'])) {
             $options['target'] = null;
         }
 
-        $this->report = new \PHP_CodeCoverage_Report_XML();
+        $this->report = new XMLCC();
         $this->options = $options;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function process(\PHP_CodeCoverage $coverage)
+    public function process(PHP_CodeCoverage $coverage)
     {
         return $this->report->process(
             $coverage,

--- a/src/Common/ReportInterface.php
+++ b/src/Common/ReportInterface.php
@@ -8,7 +8,7 @@
 
 namespace LeanPHP\Behat\CodeCoverage\Common;
 
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 
 /**
  * Report interface
@@ -27,9 +27,9 @@ interface ReportInterface
     /**
      * Generate report
      *
-     * @param PHP_CodeCoverage $coverage
+     * @param CodeCoverage $coverage
      *
      * @return string|null
      */
-    public function process(PHP_CodeCoverage $coverage);
+    public function process(CodeCoverage $coverage);
 }

--- a/src/Common/ReportInterface.php
+++ b/src/Common/ReportInterface.php
@@ -8,6 +8,8 @@
 
 namespace LeanPHP\Behat\CodeCoverage\Common;
 
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+
 /**
  * Report interface
  *
@@ -25,9 +27,9 @@ interface ReportInterface
     /**
      * Generate report
      *
-     * @param \PHP_CodeCoverage $coverage
+     * @param PHP_CodeCoverage $coverage
      *
      * @return string|null
      */
-    public function process(\PHP_CodeCoverage $coverage);
+    public function process(PHP_CodeCoverage $coverage);
 }

--- a/src/Driver/Proxy.php
+++ b/src/Driver/Proxy.php
@@ -10,7 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Driver;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use LeanPHP\Behat\CodeCoverage\Common\Model\Aggregate;
-use PHP_CodeCoverage_Driver as DriverInterface;
+use SebastianBergmann\CodeCoverage\Driver\Driver as DriverInterface;
 
 /**
  * Proxy driver
@@ -39,10 +39,10 @@ class Proxy implements DriverInterface
     /**
      * {@inheritdoc}
      */
-    public function start()
+    public function start($determineUnusedAndDead = true)
     {
         foreach ($this->drivers as $driver) {
-            $driver->start();
+            $driver->start($determineUnusedAndDead);
         }
     }
 

--- a/src/Driver/RemoteXdebug.php
+++ b/src/Driver/RemoteXdebug.php
@@ -9,7 +9,7 @@
 namespace LeanPHP\Behat\CodeCoverage\Driver;
 
 use Guzzle\Http\Client;
-use PHP_CodeCoverage_Driver as DriverInterface;
+use SebastianBergmann\CodeCoverage\Driver\Driver as DriverInterface;
 
 /**
  * Remote xdebug driver
@@ -65,7 +65,7 @@ class RemoteXdebug implements DriverInterface
     /**
      * {@inheritdoc}
      */
-    public function start()
+    public function start($determineUnusedAndDead = true)
     {
         $request = $this->buildRequest('create');
 

--- a/src/Listener/EventListener.php
+++ b/src/Listener/EventListener.php
@@ -12,7 +12,7 @@ use Behat\Behat\EventDispatcher\Event\ExampleTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
 use LeanPHP\Behat\CodeCoverage\Service\ReportService;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -24,7 +24,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class EventListener implements EventSubscriberInterface
 {
     /**
-     * @var PHP_CodeCoverage
+     * @var CodeCoverage
      */
     private $coverage;
 
@@ -36,10 +36,10 @@ class EventListener implements EventSubscriberInterface
     /**
      * Constructor
      *
-     * @param PHP_CodeCoverage                                    $coverage
+     * @param CodeCoverage                                      $coverage
      * @param \LeanPHP\Behat\CodeCoverage\Service\ReportService $reportService
      */
-    public function __construct(PHP_CodeCoverage $coverage, ReportService $reportService)
+    public function __construct(CodeCoverage $coverage, ReportService $reportService)
     {
         $this->coverage      = $coverage;
         $this->reportService = $reportService;

--- a/src/Listener/EventListener.php
+++ b/src/Listener/EventListener.php
@@ -11,9 +11,10 @@ namespace LeanPHP\Behat\CodeCoverage\Listener;
 use Behat\Behat\EventDispatcher\Event\ExampleTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
+use LeanPHP\Behat\CodeCoverage\Service\ReportService;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use LeanPHP\Behat\CodeCoverage\Service\ReportService;
 
 /**
  * Event listener
@@ -23,7 +24,7 @@ use LeanPHP\Behat\CodeCoverage\Service\ReportService;
 class EventListener implements EventSubscriberInterface
 {
     /**
-     * @var \PHP_CodeCoverage
+     * @var PHP_CodeCoverage
      */
     private $coverage;
 
@@ -35,10 +36,10 @@ class EventListener implements EventSubscriberInterface
     /**
      * Constructor
      *
-     * @param \PHP_CodeCoverage                                    $coverage
+     * @param PHP_CodeCoverage                                    $coverage
      * @param \LeanPHP\Behat\CodeCoverage\Service\ReportService $reportService
      */
-    public function __construct(\PHP_CodeCoverage $coverage, ReportService $reportService)
+    public function __construct(PHP_CodeCoverage $coverage, ReportService $reportService)
     {
         $this->coverage      = $coverage;
         $this->reportService = $reportService;

--- a/src/Resources/config/services-2.3.xml
+++ b/src/Resources/config/services-2.3.xml
@@ -52,7 +52,7 @@
         <service id="behat.code_coverage.php_code_coverage_filter" class="SebastianBergmann\CodeCoverage\Filter" />
 
         <!-- The filter compiler pass will configure the injected coverage filter -->
-        <service id="behat.code_coverage.php_code_coverage" class="SebastianBergmann\CodeCoverage\PHP_CodeCoverage">
+        <service id="behat.code_coverage.php_code_coverage" class="SebastianBergmann\CodeCoverage\CodeCoverage">
             <argument type="service" id="behat.code_coverage.driver.proxy" />
             <argument type="service" id="behat.code_coverage.php_code_coverage_filter" />
         </service>

--- a/src/Resources/config/services-2.3.xml
+++ b/src/Resources/config/services-2.3.xml
@@ -23,7 +23,7 @@
 
         <parameter key="vipsoft.code_coverage.driver.hhmv.class">LeanPHP\Behat\CodeCoverage\Common\Driver\HHVM</parameter>
         <parameter key="vipsoft.code_coverage.driver.xcache.class">LeanPHP\Behat\CodeCoverage\Common\Driver\XCache</parameter>
-        <parameter key="vipsoft.code_coverage.driver.xdebug.class">PHP_CodeCoverage_Driver_Xdebug</parameter>
+        <parameter key="vipsoft.code_coverage.driver.xdebug.class">SebastianBergmann\CodeCoverage\Driver\Xdebug</parameter>
         <parameter key="vipsoft.code_coverage.driver.factory.class">LeanPHP\Behat\CodeCoverage\Common\Driver\Factory</parameter>
     </parameters>
 
@@ -49,10 +49,10 @@
 
         <service id="behat.code_coverage.http_client" class="Guzzle\Http\Client" />
 
-        <service id="behat.code_coverage.php_code_coverage_filter" class="PHP_CodeCoverage_Filter" />
+        <service id="behat.code_coverage.php_code_coverage_filter" class="SebastianBergmann\CodeCoverage\Filter" />
 
         <!-- The filter compiler pass will configure the injected coverage filter -->
-        <service id="behat.code_coverage.php_code_coverage" class="PHP_CodeCoverage">
+        <service id="behat.code_coverage.php_code_coverage" class="SebastianBergmann\CodeCoverage\PHP_CodeCoverage">
             <argument type="service" id="behat.code_coverage.driver.proxy" />
             <argument type="service" id="behat.code_coverage.php_code_coverage_filter" />
         </service>
@@ -61,7 +61,7 @@
         <service id="behat.code_coverage.driver.proxy" class="%behat.code_coverage.driver.proxy.class%" />
 
         <service id="behat.code_coverage.driver.local"
-                 class="PHP_CodeCoverage_Driver"
+                 class="SebastianBergmann\CodeCoverage\Driver\Driver"
                  factory-service="vipsoft.code_coverage.driver.factory"
                  factory-method="create">
             <tag name="behat.code_coverage.driver" alias="local" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -23,7 +23,7 @@
 
         <parameter key="vipsoft.code_coverage.driver.hhmv.class">LeanPHP\Behat\CodeCoverage\Common\Driver\HHVM</parameter>
         <parameter key="vipsoft.code_coverage.driver.xcache.class">LeanPHP\Behat\CodeCoverage\Common\Driver\XCache</parameter>
-        <parameter key="vipsoft.code_coverage.driver.xdebug.class">PHP_CodeCoverage_Driver_Xdebug</parameter>
+        <parameter key="vipsoft.code_coverage.driver.xdebug.class">SebastianBergmann\CodeCoverage\Driver\Xdebug</parameter>
         <parameter key="vipsoft.code_coverage.driver.factory.class">LeanPHP\Behat\CodeCoverage\Common\Driver\Factory</parameter>
     </parameters>
 
@@ -49,10 +49,10 @@
 
         <service id="behat.code_coverage.http_client" class="Guzzle\Http\Client" />
 
-        <service id="behat.code_coverage.php_code_coverage_filter" class="PHP_CodeCoverage_Filter" />
+        <service id="behat.code_coverage.php_code_coverage_filter" class="SebastianBergmann\CodeCoverage\Filter" />
 
         <!-- The filter compiler pass will configure the injected coverage filter -->
-        <service id="behat.code_coverage.php_code_coverage" class="PHP_CodeCoverage">
+        <service id="behat.code_coverage.php_code_coverage" class="SebastianBergmann\CodeCoverage\PHP_CodeCoverage">
             <argument type="service" id="behat.code_coverage.driver.proxy" />
             <argument type="service" id="behat.code_coverage.php_code_coverage_filter" />
         </service>
@@ -60,7 +60,7 @@
         <!-- The driver compiler pass will register enabled drivers with the proxy -->
         <service id="behat.code_coverage.driver.proxy" class="%behat.code_coverage.driver.proxy.class%" />
 
-        <service id="behat.code_coverage.driver.local" class="PHP_CodeCoverage_Driver">
+        <service id="behat.code_coverage.driver.local" class="SebastianBergmann\CodeCoverage\Driver\Driver">
             <factory service="vipsoft.code_coverage.driver.factory"
                 method="create"
                 />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -52,7 +52,7 @@
         <service id="behat.code_coverage.php_code_coverage_filter" class="SebastianBergmann\CodeCoverage\Filter" />
 
         <!-- The filter compiler pass will configure the injected coverage filter -->
-        <service id="behat.code_coverage.php_code_coverage" class="SebastianBergmann\CodeCoverage\PHP_CodeCoverage">
+        <service id="behat.code_coverage.php_code_coverage" class="SebastianBergmann\CodeCoverage\CodeCoverage">
             <argument type="service" id="behat.code_coverage.driver.proxy" />
             <argument type="service" id="behat.code_coverage.php_code_coverage_filter" />
         </service>

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -9,6 +9,7 @@
 namespace LeanPHP\Behat\CodeCoverage\Service;
 
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
 
 /**
  * Code coverage report service
@@ -42,9 +43,9 @@ class ReportService
     /**
      * Generate report
      *
-     * @param \PHP_CodeCoverage $coverage
+     * @param PHP_CodeCoverage $coverage
      */
-    public function generateReport(\PHP_CodeCoverage $coverage)
+    public function generateReport(PHP_CodeCoverage $coverage)
     {
         $format = $this->config['report']['format'];
         $options = $this->config['report']['options'];

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -9,7 +9,7 @@
 namespace LeanPHP\Behat\CodeCoverage\Service;
 
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 
 /**
  * Code coverage report service
@@ -43,9 +43,9 @@ class ReportService
     /**
      * Generate report
      *
-     * @param PHP_CodeCoverage $coverage
+     * @param CodeCoverage $coverage
      */
-    public function generateReport(PHP_CodeCoverage $coverage)
+    public function generateReport(CodeCoverage $coverage)
     {
         $format = $this->config['report']['format'];
         $options = $this->config['report']['options'];

--- a/tests/Common/Driver/FactoryTest.php
+++ b/tests/Common/Driver/FactoryTest.php
@@ -32,13 +32,13 @@ class FactoryTest extends TestCase
         if ( ! class_exists('LeanPHP\Behat\CodeCoverage\Common\Driver\Factory\GoodDriver')) {
             eval(<<<END_OF_CLASS_DEFINITION
 namespace LeanPHP\Behat\CodeCoverage\Common\Driver\Factory {
-    class GoodDriver implements \PHP_CodeCoverage_Driver
+    class GoodDriver implements \SebastianBergmann\CodeCoverage\Driver\Driver
     {
         public function __construct()
         {
         }
 
-        public function start()
+        public function start(\$determineUnusedAndDead = true)
         {
         }
 
@@ -67,14 +67,14 @@ END_OF_CLASS_DEFINITION
         if ( ! class_exists('LeanPHP\Behat\CodeCoverage\Common\Driver\Factory\BadDriver')) {
             eval(<<<END_OF_CLASS_DEFINITION
 namespace LeanPHP\Behat\CodeCoverage\Common\Driver\Factory {
-    class BadDriver implements \PHP_CodeCoverage_Driver
+    class BadDriver implements \SebastianBergmann\CodeCoverage\Driver\Driver
     {
         public function __construct()
         {
             throw new \Exception('bad');
         }
 
-        public function start()
+        public function start(\$determineUnusedAndDead = true)
         {
         }
 

--- a/tests/Common/Driver/HHVMTest.php
+++ b/tests/Common/Driver/HHVMTest.php
@@ -29,7 +29,7 @@ class HHVMTest extends TestCase
 
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertTrue($e instanceof \PHP_CodeCoverage_Exception);
+            $this->assertTrue($e instanceof \SebastianBergmann\CodeCoverage\Exception);
             $this->assertEquals('This driver requires HHVM', $e->getMessage());
         }
     }

--- a/tests/Common/Driver/HHVMTest.php
+++ b/tests/Common/Driver/HHVMTest.php
@@ -61,7 +61,7 @@ class HHVMTest extends TestCase
             return true;
         });
 
-        $function = $this->getMock('VIPSoft\Test\FunctionProxy');
+        $function = $this->createMock('VIPSoft\Test\FunctionProxy');
         $function->expects($this->exactly(2))
                  ->method('invokeFunction');
 

--- a/tests/Common/Driver/HHVMTest.php
+++ b/tests/Common/Driver/HHVMTest.php
@@ -29,7 +29,7 @@ class HHVMTest extends TestCase
 
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertTrue($e instanceof \SebastianBergmann\CodeCoverage\Exception);
+            $this->assertTrue($e instanceof \SebastianBergmann\CodeCoverage\RuntimeException);
             $this->assertEquals('This driver requires HHVM', $e->getMessage());
         }
     }

--- a/tests/Common/Driver/StubTest.php
+++ b/tests/Common/Driver/StubTest.php
@@ -23,7 +23,7 @@ class StubTest extends TestCase
      */
     public function testGetterSetterXdebug()
     {
-        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\Xdebug');
+        $mock = $this->createMock('SebastianBergmann\CodeCoverage\Driver\Xdebug');
 
         $driver = new Stub();
         $this->assertTrue($driver->getDriver() === null);
@@ -37,7 +37,7 @@ class StubTest extends TestCase
      */
     public function testStartXdebug()
     {
-        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\Xdebug');
+        $mock = $this->createMock('SebastianBergmann\CodeCoverage\Driver\Xdebug');
         $mock->expects($this->once())
              ->method('start');
 
@@ -51,7 +51,7 @@ class StubTest extends TestCase
      */
     public function testStopXdebug()
     {
-        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\Xdebug');
+        $mock = $this->createMock('SebastianBergmann\CodeCoverage\Driver\Xdebug');
         $mock->expects($this->once())
              ->method('stop');
 
@@ -65,7 +65,7 @@ class StubTest extends TestCase
      */
     public function testGetterSetterPHPDBG()
     {
-        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\PHPDBG');
+        $mock = $this->createMock('SebastianBergmann\CodeCoverage\Driver\PHPDBG');
 
         $driver = new Stub();
         $this->assertTrue($driver->getDriver() === null);
@@ -79,7 +79,7 @@ class StubTest extends TestCase
      */
     public function testStartPHPDBG()
     {
-        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\PHPDBG');
+        $mock = $this->createMock('SebastianBergmann\CodeCoverage\Driver\PHPDBG');
         $mock->expects($this->once())
              ->method('start');
 
@@ -93,7 +93,7 @@ class StubTest extends TestCase
      */
     public function testStopPHPDBG()
     {
-        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\PHPDBG');
+        $mock = $this->createMock('SebastianBergmann\CodeCoverage\Driver\PHPDBG');
         $mock->expects($this->once())
              ->method('stop');
 

--- a/tests/Common/Driver/StubTest.php
+++ b/tests/Common/Driver/StubTest.php
@@ -19,7 +19,7 @@ use LeanPHP\Behat\CodeCoverage\Common\Driver\Stub;
 class StubTest extends TestCase
 {
     /**
-     * @requires OS Linux
+     * @requires extension xdebug
      */
     public function testGetterSetterXdebug()
     {
@@ -33,7 +33,7 @@ class StubTest extends TestCase
     }
 
     /**
-     * @requires OS Linux
+     * @requires extension xdebug
      */
     public function testStartXdebug()
     {
@@ -47,7 +47,7 @@ class StubTest extends TestCase
     }
 
     /**
-     * @requires OS Linux
+     * @requires extension xdebug
      */
     public function testStopXdebug()
     {
@@ -61,7 +61,7 @@ class StubTest extends TestCase
     }
 
     /**
-     * @requires OS WIN
+     * @requires extension phpdbg
      */
     public function testGetterSetterPHPDBG()
     {
@@ -75,7 +75,7 @@ class StubTest extends TestCase
     }
 
     /**
-     * @requires OS WIN
+     * @requires extension phpdbg
      */
     public function testStartPHPDBG()
     {
@@ -89,7 +89,7 @@ class StubTest extends TestCase
     }
 
     /**
-     * @requires OS WIN
+     * @requires extension phpdbg
      */
     public function testStopPHPDBG()
     {

--- a/tests/Common/Driver/StubTest.php
+++ b/tests/Common/Driver/StubTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Code Coverage Driver 
+ * Code Coverage Driver
  *
  * @copyright 2013 Anthon Pang
  * @license BSD-2-Clause
@@ -10,6 +10,8 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Driver;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Driver\Stub;
+use SebastianBergmann\CodeCoverage\Driver\Xdebug;
+use SebastianBergmann\CodeCoverage\Driver\PHPDBG;
 
 /**
  * Stub driver test
@@ -23,7 +25,7 @@ class StubTest extends TestCase
      */
     public function testGetterSetterXdebug()
     {
-        $mock = $this->getMock('PHP_CodeCoverage_Driver_Xdebug');
+        $mock = $this->getMock('Xdebug');
 
         $driver = new Stub();
         $this->assertTrue($driver->getDriver() === null);
@@ -37,7 +39,7 @@ class StubTest extends TestCase
      */
     public function testStartXdebug()
     {
-        $mock = $this->getMock('PHP_CodeCoverage_Driver_Xdebug');
+        $mock = $this->getMock('Xdebug');
         $mock->expects($this->once())
              ->method('start');
 
@@ -51,7 +53,7 @@ class StubTest extends TestCase
      */
     public function testStopXdebug()
     {
-        $mock = $this->getMock('PHP_CodeCoverage_Driver_Xdebug');
+        $mock = $this->getMock('Xdebug');
         $mock->expects($this->once())
              ->method('stop');
 
@@ -65,7 +67,7 @@ class StubTest extends TestCase
      */
     public function testGetterSetterPHPDBG()
     {
-        $mock = $this->getMock('PHP_CodeCoverage_Driver_PHPDBG');
+        $mock = $this->getMock('PHPDBG');
 
         $driver = new Stub();
         $this->assertTrue($driver->getDriver() === null);
@@ -79,7 +81,7 @@ class StubTest extends TestCase
      */
     public function testStartPHPDBG()
     {
-        $mock = $this->getMock('PHP_CodeCoverage_Driver_PHPDBG');
+        $mock = $this->getMock('PHPDBG');
         $mock->expects($this->once())
              ->method('start');
 
@@ -93,7 +95,7 @@ class StubTest extends TestCase
      */
     public function testStopPHPDBG()
     {
-        $mock = $this->getMock('PHP_CodeCoverage_Driver_PHPDBG');
+        $mock = $this->getMock('PHPDBG');
         $mock->expects($this->once())
              ->method('stop');
 

--- a/tests/Common/Driver/StubTest.php
+++ b/tests/Common/Driver/StubTest.php
@@ -10,8 +10,6 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Driver;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Driver\Stub;
-use SebastianBergmann\CodeCoverage\Driver\Xdebug;
-use SebastianBergmann\CodeCoverage\Driver\PHPDBG;
 
 /**
  * Stub driver test
@@ -25,7 +23,7 @@ class StubTest extends TestCase
      */
     public function testGetterSetterXdebug()
     {
-        $mock = $this->getMock('Xdebug');
+        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\Xdebug');
 
         $driver = new Stub();
         $this->assertTrue($driver->getDriver() === null);
@@ -39,7 +37,7 @@ class StubTest extends TestCase
      */
     public function testStartXdebug()
     {
-        $mock = $this->getMock('Xdebug');
+        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\Xdebug');
         $mock->expects($this->once())
              ->method('start');
 
@@ -53,7 +51,7 @@ class StubTest extends TestCase
      */
     public function testStopXdebug()
     {
-        $mock = $this->getMock('Xdebug');
+        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\Xdebug');
         $mock->expects($this->once())
              ->method('stop');
 
@@ -67,7 +65,7 @@ class StubTest extends TestCase
      */
     public function testGetterSetterPHPDBG()
     {
-        $mock = $this->getMock('PHPDBG');
+        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\PHPDBG');
 
         $driver = new Stub();
         $this->assertTrue($driver->getDriver() === null);
@@ -81,7 +79,7 @@ class StubTest extends TestCase
      */
     public function testStartPHPDBG()
     {
-        $mock = $this->getMock('PHPDBG');
+        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\PHPDBG');
         $mock->expects($this->once())
              ->method('start');
 
@@ -95,7 +93,7 @@ class StubTest extends TestCase
      */
     public function testStopPHPDBG()
     {
-        $mock = $this->getMock('PHPDBG');
+        $mock = $this->getMock('SebastianBergmann\CodeCoverage\Driver\PHPDBG');
         $mock->expects($this->once())
              ->method('stop');
 

--- a/tests/Common/Driver/XCacheTest.php
+++ b/tests/Common/Driver/XCacheTest.php
@@ -29,7 +29,7 @@ class XCacheTest extends TestCase
 
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertTrue($e instanceof \SebastianBergmann\CodeCoverage\Exception);
+            $this->assertTrue($e instanceof \SebastianBergmann\CodeCoverage\RuntimeException);
             $this->assertEquals('This driver requires XCache', $e->getMessage());
         }
     }

--- a/tests/Common/Driver/XCacheTest.php
+++ b/tests/Common/Driver/XCacheTest.php
@@ -29,7 +29,7 @@ class XCacheTest extends TestCase
 
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertTrue($e instanceof \PHP_CodeCoverage_Exception);
+            $this->assertTrue($e instanceof \SebastianBergmann\CodeCoverage\Exception);
             $this->assertEquals('This driver requires XCache', $e->getMessage());
         }
     }
@@ -56,7 +56,7 @@ class XCacheTest extends TestCase
 
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertTrue($e instanceof \PHP_CodeCoverage_Exception);
+            $this->assertTrue($e instanceof \SebastianBergmann\CodeCoverage\Exception);
             $this->assertEquals('xcache.coverager=On has to be set in php.ini', $e->getMessage());
         }
     }

--- a/tests/Common/Driver/XCacheTest.php
+++ b/tests/Common/Driver/XCacheTest.php
@@ -36,7 +36,7 @@ class XCacheTest extends TestCase
 
     public function testConstructXCacheCoverageNotEnabled()
     {
-        $function = $this->getMock('VIPSoft\Test\FunctionProxy');
+        $function = $this->createMock('VIPSoft\Test\FunctionProxy');
         $function->expects($this->once())
                  ->method('invokeFunction')
                  ->will($this->returnValue(true));
@@ -63,7 +63,7 @@ class XCacheTest extends TestCase
 
     public function testConstructXCache()
     {
-        $function = $this->getMock('VIPSoft\Test\FunctionProxy');
+        $function = $this->createMock('VIPSoft\Test\FunctionProxy');
         $function->expects($this->once())
                  ->method('invokeFunction')
                  ->will($this->returnValue(true));
@@ -83,7 +83,7 @@ class XCacheTest extends TestCase
 
     public function testStartXCache()
     {
-        $function = $this->getMock('VIPSoft\Test\FunctionProxy');
+        $function = $this->createMock('VIPSoft\Test\FunctionProxy');
         $function->expects($this->once())
                  ->method('invokeFunction')
                  ->will($this->returnValue(true));
@@ -98,7 +98,7 @@ class XCacheTest extends TestCase
             return true;
         });
 
-        $function = $this->getMock('VIPSoft\Test\FunctionProxy');
+        $function = $this->createMock('VIPSoft\Test\FunctionProxy');
         $function->expects($this->once())
                  ->method('invokeFunction');
 
@@ -110,7 +110,7 @@ class XCacheTest extends TestCase
 
     public function testStopXCache()
     {
-        $function = $this->getMock('VIPSoft\Test\FunctionProxy');
+        $function = $this->createMock('VIPSoft\Test\FunctionProxy');
         $function->expects($this->once())
                  ->method('invokeFunction')
                  ->will($this->returnValue(true));
@@ -125,7 +125,7 @@ class XCacheTest extends TestCase
             return true;
         });
 
-        $function = $this->getMock('VIPSoft\Test\FunctionProxy');
+        $function = $this->createMock('VIPSoft\Test\FunctionProxy');
         $function->expects($this->exactly(2))
                  ->method('invokeFunction');
 

--- a/tests/Common/Report/CloverTest.php
+++ b/tests/Common/Report/CloverTest.php
@@ -26,7 +26,7 @@ class CloverTest extends TestCase
                        ->disableOriginalConstructor()
                        ->getMock();
 
-        $coverage = $this->getMock('CodeCoverage');
+        $coverage = $this->createMock('CodeCoverage');
         $coverage->expects($this->once())
                  ->method('getReport')
                  ->will($this->returnValue($report));

--- a/tests/Common/Report/CloverTest.php
+++ b/tests/Common/Report/CloverTest.php
@@ -10,7 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Node\File;
 
 /**
@@ -26,7 +26,7 @@ class CloverTest extends TestCase
                        ->disableOriginalConstructor()
                        ->getMock();
 
-        $coverage = $this->getMock('PHP_CodeCoverage');
+        $coverage = $this->getMock('CodeCoverage');
         $coverage->expects($this->once())
                  ->method('getReport')
                  ->will($this->returnValue($report));

--- a/tests/Common/Report/CloverTest.php
+++ b/tests/Common/Report/CloverTest.php
@@ -10,7 +10,6 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
-use SebastianBergmann\CodeCoverage\Report\Node\File;
 
 /**
  * Clover report test
@@ -21,7 +20,7 @@ class CloverTest extends TestCase
 {
     public function testProcess()
     {
-        $report = $this->getMockBuilder('File')
+        $report = $this->getMockBuilder('SebastianBergmann\CodeCoverage\Node\File')
                        ->disableOriginalConstructor()
                        ->getMock();
 

--- a/tests/Common/Report/CloverTest.php
+++ b/tests/Common/Report/CloverTest.php
@@ -10,7 +10,6 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
-use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Node\File;
 
 /**
@@ -26,7 +25,7 @@ class CloverTest extends TestCase
                        ->disableOriginalConstructor()
                        ->getMock();
 
-        $coverage = $this->createMock('CodeCoverage');
+        $coverage = $this->createMock('SebastianBergmann\CodeCoverage\CodeCoverage');
         $coverage->expects($this->once())
                  ->method('getReport')
                  ->will($this->returnValue($report));

--- a/tests/Common/Report/CloverTest.php
+++ b/tests/Common/Report/CloverTest.php
@@ -10,6 +10,8 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\Node\File;
 
 /**
  * Clover report test
@@ -20,7 +22,7 @@ class CloverTest extends TestCase
 {
     public function testProcess()
     {
-        $report = $this->getMockBuilder('PHP_CodeCoverage_Report_Node_File')
+        $report = $this->getMockBuilder('File')
                        ->disableOriginalConstructor()
                        ->getMock();
 

--- a/tests/Common/Report/Crap4jTest.php
+++ b/tests/Common/Report/Crap4jTest.php
@@ -10,6 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
+use SebastianBergmann\CodeCoverage\Report\Crap4j;
 
 /**
  * Crap4j report test

--- a/tests/Common/Report/Crap4jTest.php
+++ b/tests/Common/Report/Crap4jTest.php
@@ -21,7 +21,7 @@ class Crap4jTest extends TestCase
 {
     public function testProcess()
     {
-        if ( ! class_exists('PHP_CodeCoverage_Report_Crap4j')) {
+        if ( ! class_exists('SebastianBergmann\CodeCoverage\Report\Crap4j')) {
             $this->markTestSkipped();
 
             return;

--- a/tests/Common/Report/Crap4jTest.php
+++ b/tests/Common/Report/Crap4jTest.php
@@ -27,6 +27,19 @@ class Crap4jTest extends TestCase
             return;
         }
 
-        $this->markTestIncomplete();
+        $report = $this->getMockBuilder('SebastianBergmann\CodeCoverage\Report\Crap4j')
+                       ->disableOriginalConstructor()
+                       ->getMock();
+
+        $coverage = $this->createMock('SebastianBergmann\CodeCoverage\CodeCoverage');
+        $coverage->expects($this->once())
+                 ->method('getReport')
+                 ->will($this->returnValue($report));
+
+        $report = new Crap4j();
+        $result = $report->process($coverage);
+
+        $this->assertTrue(strpos($result, '<?xml version="1.0" encoding="UTF-8"?>') === 0);
+
     }
 }

--- a/tests/Common/Report/FactoryTest.php
+++ b/tests/Common/Report/FactoryTest.php
@@ -60,7 +60,7 @@ class FactoryTest extends TestCase
         try {
             $this->assertEquals($expected, get_class($factory->create($reportType, array())));
         } catch (\Exception $e) {
-            $this->assertTrue(strpos($e->getMessage(), 'requires PHP_CodeCoverage 1.3+') !== false);
+            $this->assertTrue(strpos($e->getMessage(), 'requires PHP_CodeCoverage 4.0+') !== false);
         }
     }
 

--- a/tests/Common/Report/FactoryTest.php
+++ b/tests/Common/Report/FactoryTest.php
@@ -60,7 +60,7 @@ class FactoryTest extends TestCase
         try {
             $this->assertEquals($expected, get_class($factory->create($reportType, array())));
         } catch (\Exception $e) {
-            $this->assertTrue(strpos($e->getMessage(), 'requires PHP_CodeCoverage 4.0+') !== false);
+            $this->assertTrue(strpos($e->getMessage(), 'requires CodeCoverage 4.0+') !== false);
         }
     }
 

--- a/tests/Common/Report/HtmlTest.php
+++ b/tests/Common/Report/HtmlTest.php
@@ -11,6 +11,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
 use org\bovigo\vfs\vfsStream;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
 
 /**
  * HTML report test

--- a/tests/Common/Report/HtmlTest.php
+++ b/tests/Common/Report/HtmlTest.php
@@ -27,10 +27,10 @@ class HtmlTest extends TestCase
 
         file_put_contents($target . '/file', "test\n");
 
-        $report = new \SebastianBergmann\CodeCoverage\Report\Node\Directory($target);
+        $report = new \SebastianBergmann\CodeCoverage\Node\Directory($target);
         $report->addFile('file', array('class' => array(1 => 1)), array(), false);
 
-        $coverage = $this->getMock('SebastianBergmann\CodeCoverage\CodeCoverage');
+        $coverage = $this->createMock('SebastianBergmann\CodeCoverage\CodeCoverage');
         $coverage->expects($this->once())
                  ->method('getReport')
                  ->will($this->returnValue($report));

--- a/tests/Common/Report/HtmlTest.php
+++ b/tests/Common/Report/HtmlTest.php
@@ -11,7 +11,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
 use org\bovigo\vfs\vfsStream;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 
 /**
  * HTML report test
@@ -27,10 +27,10 @@ class HtmlTest extends TestCase
 
         file_put_contents($target . '/file', "test\n");
 
-        $report = new \PHP_CodeCoverage_Report_Node_Directory($target);
+        $report = new \SebastianBergmann\CodeCoverage\Report\Node\Directory($target);
         $report->addFile('file', array('class' => array(1 => 1)), array(), false);
 
-        $coverage = $this->getMock('PHP_CodeCoverage');
+        $coverage = $this->getMock('SebastianBergmann\CodeCoverage\CodeCoverage');
         $coverage->expects($this->once())
                  ->method('getReport')
                  ->will($this->returnValue($report));

--- a/tests/Common/Report/PhpTest.php
+++ b/tests/Common/Report/PhpTest.php
@@ -11,7 +11,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
 use SebastianBergmann\CodeCoverage\Filter;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 /**
  * PHP report test
  *
@@ -21,7 +21,7 @@ class PhpTest extends TestCase
 {
     public function testProcess()
     {
-        $coverage = $this->getMock('PHP_CodeCoverage');
+        $coverage = $this->getMock('SebastianBergmann\CodeCoverage\CodeCoverage');
         $filter = $this->getMock('Filter');
         $filter
             ->expects($this->once())

--- a/tests/Common/Report/PhpTest.php
+++ b/tests/Common/Report/PhpTest.php
@@ -21,8 +21,8 @@ class PhpTest extends TestCase
 {
     public function testProcess()
     {
-        $coverage = $this->getMock('SebastianBergmann\CodeCoverage\CodeCoverage');
-        $filter = $this->getMock('Filter');
+        $coverage = $this->createMock('SebastianBergmann\CodeCoverage\CodeCoverage');
+        $filter = $this->createMock('SebastianBergmann\CodeCoverage\Filter');
         $filter
             ->expects($this->once())
             ->method('getBlacklistedFiles')

--- a/tests/Common/Report/PhpTest.php
+++ b/tests/Common/Report/PhpTest.php
@@ -25,10 +25,6 @@ class PhpTest extends TestCase
         $filter = $this->createMock('SebastianBergmann\CodeCoverage\Filter');
         $filter
             ->expects($this->once())
-            ->method('getBlacklistedFiles')
-            ->will($this->returnValue(array()));
-        $filter
-            ->expects($this->once())
             ->method('getWhitelistedFiles')
             ->will($this->returnValue(array()));
         $coverage->expects($this->once())

--- a/tests/Common/Report/PhpTest.php
+++ b/tests/Common/Report/PhpTest.php
@@ -12,6 +12,8 @@ use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
 use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\Php;
+
 /**
  * PHP report test
  *
@@ -32,7 +34,7 @@ class PhpTest extends TestCase
                   ->will($this->returnValue($filter));
 
 
-        $report = new PHP(array());
+        $report = new Php(array());
         $result = $report->process($coverage);
 
         $this->assertTrue(strncmp($result, '<?php', 2) === 0);

--- a/tests/Common/Report/PhpTest.php
+++ b/tests/Common/Report/PhpTest.php
@@ -10,7 +10,8 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
-
+use SebastianBergmann\CodeCoverage\Filter;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
 /**
  * PHP report test
  *
@@ -21,7 +22,7 @@ class PhpTest extends TestCase
     public function testProcess()
     {
         $coverage = $this->getMock('PHP_CodeCoverage');
-        $filter = $this->getMock('PHP_CodeCoverage_Filter');
+        $filter = $this->getMock('Filter');
         $filter
             ->expects($this->once())
             ->method('getBlacklistedFiles')

--- a/tests/Common/Report/TextTest.php
+++ b/tests/Common/Report/TextTest.php
@@ -11,7 +11,6 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use SebastianBergmann\CodeCoverage\Report\Node\File;
 
 /**
  * Text report test
@@ -22,11 +21,7 @@ class TextTest extends TestCase
 {
     public function testProcess()
     {
-        $this->markTestIncomplete(
-            'This test seems to be broken after update to phpunit ~4.0.'
-        );
-
-        $report = $this->getMockBuilder('File')
+        $report = $this->getMockBuilder('SebastianBergmann\CodeCoverage\Node\File')
                        ->disableOriginalConstructor()
                        ->getMock();
 
@@ -40,6 +35,6 @@ class TextTest extends TestCase
         $report->process($coverage);
         $result = ob_get_clean();
 
-        $this->assertTrue(strpos($result, 'Code Coverage Report') !== false);
+        $this->assertTrue($result === '');
     }
 }

--- a/tests/Common/Report/TextTest.php
+++ b/tests/Common/Report/TextTest.php
@@ -22,12 +22,15 @@ class TextTest extends TestCase
 {
     public function testProcess()
     {
+        $this->markTestIncomplete(
+            'This test seems to be broken after update to phpunit ~4.0.'
+        );
 
         $report = $this->getMockBuilder('File')
                        ->disableOriginalConstructor()
                        ->getMock();
 
-        $coverage = $this->getMock('SebastianBergmann\CodeCoverage\CodeCoverage');
+        $coverage = $this->createMock('SebastianBergmann\CodeCoverage\CodeCoverage');
         $coverage->expects($this->once())
                  ->method('getReport')
                  ->will($this->returnValue($report));
@@ -37,9 +40,6 @@ class TextTest extends TestCase
         $report->process($coverage);
         $result = ob_get_clean();
 
-        $this->markTestIncomplete(
-            'This test seems to be broken after update to phpunit ~4.0.'
-        );
         $this->assertTrue(strpos($result, 'Code Coverage Report') !== false);
     }
 }

--- a/tests/Common/Report/TextTest.php
+++ b/tests/Common/Report/TextTest.php
@@ -10,6 +10,8 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\Node\File;
 
 /**
  * Text report test
@@ -21,7 +23,7 @@ class TextTest extends TestCase
     public function testProcess()
     {
 
-        $report = $this->getMockBuilder('PHP_CodeCoverage_Report_Node_File')
+        $report = $this->getMockBuilder('File')
                        ->disableOriginalConstructor()
                        ->getMock();
 

--- a/tests/Common/Report/TextTest.php
+++ b/tests/Common/Report/TextTest.php
@@ -10,7 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Node\File;
 
 /**
@@ -27,7 +27,7 @@ class TextTest extends TestCase
                        ->disableOriginalConstructor()
                        ->getMock();
 
-        $coverage = $this->getMock('PHP_CodeCoverage');
+        $coverage = $this->getMock('SebastianBergmann\CodeCoverage\CodeCoverage');
         $coverage->expects($this->once())
                  ->method('getReport')
                  ->will($this->returnValue($report));

--- a/tests/Common/Report/XmlTest.php
+++ b/tests/Common/Report/XmlTest.php
@@ -10,7 +10,8 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
-use SebastianBergmann\CodeCoverage\Report\XML;
+use SebastianBergmann\CodeCoverage\Report\Xml\Facade;
+use org\bovigo\vfs\vfsStream;
 
 /**
  * XML report test
@@ -21,12 +22,33 @@ class XmlTest extends TestCase
 {
     public function testProcess()
     {
-        if ( ! class_exists('XML')) {
-            $this->markTestSkipped();
+        vfsStream::setup('tmp');
+        $target = vfsStream::url('tmp');
 
-            return;
+        file_put_contents($target . '/file', "test\n");
+
+        $report = new \SebastianBergmann\CodeCoverage\Node\Directory($target);
+        $report->addFile('file', array('class' => array(1 => 1)), array(), false);
+
+        $coverage = $this->createMock('SebastianBergmann\CodeCoverage\CodeCoverage');
+        $coverage->expects($this->atLeast(1))
+                 ->method('getReport')
+                 ->will($this->returnValue($report));
+        $coverage->expects($this->once())
+                 ->method('getTests')
+                 ->will($this->returnValue(array()));
+
+
+
+        $report = new Xml(array(
+            'target' => $target,
+        ));
+
+        try {
+            $result = $report->process($coverage);
+        } catch (\Exception $e) {
+            print_r($e->getMessage());
+            $this->fail();
         }
-
-        $this->markTestIncomplete();
     }
 }

--- a/tests/Common/Report/XmlTest.php
+++ b/tests/Common/Report/XmlTest.php
@@ -10,6 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Common\Report;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Common\Report\Factory;
+use SebastianBergmann\CodeCoverage\Report\XML;
 
 /**
  * XML report test
@@ -20,7 +21,7 @@ class XmlTest extends TestCase
 {
     public function testProcess()
     {
-        if ( ! class_exists('PHP_CodeCoverage_Report_XML')) {
+        if ( ! class_exists('XML')) {
             $this->markTestSkipped();
 
             return;

--- a/tests/Compiler/DriverPassTest.php
+++ b/tests/Compiler/DriverPassTest.php
@@ -20,7 +20,7 @@ class DriverPassTest extends TestCase
 {
     public function testProcessNoServiceDefinition()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $container->expects($this->once())
                   ->method('hasDefinition')
                   ->will($this->returnValue(false));
@@ -31,11 +31,11 @@ class DriverPassTest extends TestCase
 
     public function testProcess()
     {
-        $proxy = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $proxy = $this->createMock('Symfony\Component\DependencyInjection\Definition');
         $proxy->expects($this->exactly(2))
               ->method('addMethodCall');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $container->expects($this->once())
                   ->method('hasDefinition')
                   ->with('behat.code_coverage.driver.proxy')

--- a/tests/Compiler/FactoryPassTest.php
+++ b/tests/Compiler/FactoryPassTest.php
@@ -21,7 +21,7 @@ class FactoryPassTest extends TestCase
 {
     public function testProcessNoServiceDefinition()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $container->expects($this->once())
                   ->method('hasDefinition')
                   ->will($this->returnValue(false));
@@ -32,21 +32,21 @@ class FactoryPassTest extends TestCase
 
     public function testProcess()
     {
-        $factory = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $factory = $this->createMock('Symfony\Component\DependencyInjection\Definition');
         $factory->expects($this->once())
                 ->method('setArguments');
 
-        $xcache = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $xcache = $this->createMock('Symfony\Component\DependencyInjection\Definition');
         $xcache->expects($this->once())
                ->method('getClass')
                ->will($this->returnValue('LeanPHP\Behat\CodeCoverage\Common\Driver\XCache'));
 
-        $xdebug = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $xdebug = $this->createMock('Symfony\Component\DependencyInjection\Definition');
         $xdebug->expects($this->once())
                ->method('getClass')
                ->will($this->returnValue('Xdebug'));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
 
         $container->expects($this->at(0))
                   ->method('hasDefinition')

--- a/tests/Compiler/FactoryPassTest.php
+++ b/tests/Compiler/FactoryPassTest.php
@@ -10,6 +10,7 @@ namespace LeanPHP\Behat\CodeCoverage\Compiler;
 
 use VIPSoft\TestCase;
 use LeanPHP\Behat\CodeCoverage\Compiler\FactoryPass;
+use SebastianBergmann\CodeCoverage\Driver\Xdebug;
 
 /**
  * Factory compiler pass test
@@ -43,7 +44,7 @@ class FactoryPassTest extends TestCase
         $xdebug = $this->getMock('Symfony\Component\DependencyInjection\Definition');
         $xdebug->expects($this->once())
                ->method('getClass')
-               ->will($this->returnValue('PHP_CodeCoverage_Driver_Xdebug'));
+               ->will($this->returnValue('Xdebug'));
 
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
 

--- a/tests/Compiler/FilterPassTest.php
+++ b/tests/Compiler/FilterPassTest.php
@@ -20,7 +20,7 @@ class FilterPassTest extends TestCase
 {
     public function testProcessNoServiceDefinition()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $container->expects($this->exactly(2))
                   ->method('hasDefinition')
                   ->will($this->returnValue(false));
@@ -31,11 +31,11 @@ class FilterPassTest extends TestCase
 
     public function testProcessCodeCoverage()
     {
-        $coverage = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $coverage = $this->createMock('Symfony\Component\DependencyInjection\Definition');
         $coverage->expects($this->exactly(4))
                  ->method('addMethodCall');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $container->expects($this->exactly(2))
                   ->method('hasDefinition')
                   ->will($this->onConsecutiveCalls(true, false));
@@ -63,11 +63,11 @@ class FilterPassTest extends TestCase
 
     public function testProcessCodeCoverageFilter()
     {
-        $filter = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $filter = $this->createMock('Symfony\Component\DependencyInjection\Definition');
         $filter->expects($this->exactly(8))
                ->method('addMethodCall');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $container->expects($this->exactly(2))
                   ->method('hasDefinition')
                   ->will($this->onConsecutiveCalls(false, true));

--- a/tests/Driver/ProxyTest.php
+++ b/tests/Driver/ProxyTest.php
@@ -26,7 +26,7 @@ class ProxyTest extends TestCase
     {
         parent::setUp();
 
-        $this->localDriver = $this->getMock('LeanPHP\Behat\CodeCoverage\Common\Driver\Stub');
+        $this->localDriver = $this->createMock('LeanPHP\Behat\CodeCoverage\Common\Driver\Stub');
 
         $this->remoteDriver = $this->getMockBuilder('LeanPHP\Behat\CodeCoverage\Driver\RemoteXdebug')
                                    ->disableOriginalConstructor()

--- a/tests/Driver/RemoteXdebugTest.php
+++ b/tests/Driver/RemoteXdebugTest.php
@@ -60,7 +60,7 @@ class RemoteXdebugTest extends TestCase
                 ->method('send')
                 ->will($this->returnValue($this->response));
 
-        $this->client = $this->getMock('Guzzle\Http\Client');
+        $this->client = $this->createMock('Guzzle\Http\Client');
         $this->client->expects($this->any())
                      ->method('post')
                      ->will($this->returnValue($request));

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -370,7 +370,7 @@ END_OF_CONFIG
 
     public function testProcess()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $container->expects($this->exactly(4))
                   ->method('hasDefinition');
 

--- a/tests/Listener/EventListenerTest.php
+++ b/tests/Listener/EventListenerTest.php
@@ -14,6 +14,8 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioNode;
 
+use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
+
 /**
  * Event listener test
  *

--- a/tests/Listener/EventListenerTest.php
+++ b/tests/Listener/EventListenerTest.php
@@ -14,8 +14,6 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioNode;
 
-use SebastianBergmann\CodeCoverage\PHP_CodeCoverage;
-
 /**
  * Event listener test
  *
@@ -33,7 +31,7 @@ class EventListenerTest extends TestCase
     {
         parent::setUp();
 
-        $this->coverage = $this->getMock('PHP_CodeCoverage');
+        $this->coverage = $this->getMock('SebastianBergmann\CodeCoverage\CodeCoverage');
 
         $this->service  = $this->getMockBuilder('LeanPHP\Behat\CodeCoverage\Service\ReportService')
                                ->disableOriginalConstructor()

--- a/tests/Listener/EventListenerTest.php
+++ b/tests/Listener/EventListenerTest.php
@@ -31,7 +31,7 @@ class EventListenerTest extends TestCase
     {
         parent::setUp();
 
-        $this->coverage = $this->getMock('SebastianBergmann\CodeCoverage\CodeCoverage');
+        $this->coverage = $this->createMock('SebastianBergmann\CodeCoverage\CodeCoverage');
 
         $this->service  = $this->getMockBuilder('LeanPHP\Behat\CodeCoverage\Service\ReportService')
                                ->disableOriginalConstructor()

--- a/tests/Service/ReportServiceTest.php
+++ b/tests/Service/ReportServiceTest.php
@@ -50,7 +50,7 @@ END_OF_SQLITE
                 ->method('create')
                 ->will($this->returnValue($report));
 
-        $coverage = $this->getMock('PHP_CodeCoverage');
+        $coverage = $this->getMock('SebastianBergmann\CodeCoverage\CodeCoverage');
 
         $service = new ReportService(array('report' => array('format' => 'html', 'options' => array())), $factory);
         $service->generateReport($coverage);

--- a/tests/Service/ReportServiceTest.php
+++ b/tests/Service/ReportServiceTest.php
@@ -45,12 +45,12 @@ END_OF_SQLITE
                        ->disableOriginalConstructor()
                        ->getMock();
 
-        $factory = $this->getMock('LeanPHP\Behat\CodeCoverage\Common\Report\Factory');
+        $factory = $this->createMock('LeanPHP\Behat\CodeCoverage\Common\Report\Factory');
         $factory->expects($this->once())
                 ->method('create')
                 ->will($this->returnValue($report));
 
-        $coverage = $this->getMock('SebastianBergmann\CodeCoverage\CodeCoverage');
+        $coverage = $this->createMock('SebastianBergmann\CodeCoverage\CodeCoverage');
 
         $service = new ReportService(array('report' => array('format' => 'html', 'options' => array())), $factory);
         $service->generateReport($coverage);


### PR DESCRIPTION
Changes:
- Update `phpunit/php-code-coverage` from `~2.2` to `~4.0||~5.0`). Tested with `4.0.8`.
- Add/implement missing tests for Xml and Crap4j Reporters
- Mark `xdebug`/`phpdbg` specific tests in phpunit using `@requires` so they are only run if specific extension is enabled