### PR TITLE
Fix report output

### DIFF
--- a/src/Listener/EventListener.php
+++ b/src/Listener/EventListener.php
@@ -13,7 +13,7 @@ use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
 use LeanPHP\Behat\CodeCoverage\Service\ReportService;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use SebastianBergmann\CodeCoverage\Filter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -41,7 +41,15 @@ class EventListener implements EventSubscriberInterface
      */
     public function __construct(CodeCoverage $coverage, ReportService $reportService)
     {
-        $this->coverage      = $coverage;
+        $filter = new Filter();
+        $config = $reportService->getConfig();
+
+        $this->addDirectoryToWhitelist($config, $filter);
+        $this->addFileToWhitelist($config, $filter);
+
+        $cc = new CodeCoverage(null, $filter);
+
+        $this->coverage = $cc;
         $this->reportService = $reportService;
     }
 
@@ -102,4 +110,27 @@ class EventListener implements EventSubscriberInterface
     {
         $this->reportService->generateReport($this->coverage);
     }
+   
+    /**
+     * @param array  $config
+     * @param Filter $filter
+     */
+    private function addDirectoryToWhitelist(array $config, Filter $filter): void
+    {
+        foreach ($config['filter']['whitelist']['include']['directories'] as $directory) {
+            $filter->addDirectoryToWhitelist($directory['prefix']);
+        }
+    }
+
+    /**
+     * @param array  $config
+     * @param Filter $filter
+     */
+    private function addFileToWhitelist(array $config, Filter $filter): void
+    {
+        foreach ($config['filter']['whitelist']['include']['files'] as $file) {
+            $filter->addFileToWhitelist($file['prefix']);
+        }
+    }
+    
 }

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -53,4 +53,13 @@ class ReportService
         $report = $this->factory->create($format, $options);
         $report->process($coverage);
     }
+    
+    /**
+     * @return array
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
 }


### PR DESCRIPTION
Copy and paste form the patch provided by @golovetska https://github.com/golovetska/behat-code-coverage/commit/b883fdc721b68734ca8f000e00d7aa56c99a2906

Fixes https://github.com/leanphp/behat-code-coverage/issues/12

Not overly happy with creating new CodeCoverage in EventListener.php when it's passed into the constructor, but it works for me.  Might get the chance to look at this in more detail later...