### PR TITLE
Added coverage flag

### DIFF
--- a/src/CoverageController.php
+++ b/src/CoverageController.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Code Coverage Controller for Behat
+ *
+ * @copyright 2018 Danny Lewis
+ * @license BSD-2-Clause
+ */
+
+namespace LeanPHP\Behat\CodeCoverage;
+
+use Behat\Testwork\Cli\Controller;
+use LeanPHP\Behat\CodeCoverage\Service\ReportService;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class CoverageController implements Controller
+{
+
+    private $container;
+    private $coverage;
+    private $reportService;
+    private $compilerPasses;
+
+    public function __construct(ContainerBuilder $container, CodeCoverage $coverage, ReportService $reportService, $compilerPasses)
+    {
+        $this->container = $container;
+        $this->coverage = $coverage;
+        $this->reportService = $reportService;
+        $this->compilerPasses = $compilerPasses;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(Command $command)
+    {
+        $command->addOption('coverage', null, InputOption::VALUE_NONE, 'Generate coverage report(s)');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        if($input->getOption('coverage')) {
+
+            $this->container->get('event_dispatcher')->addSubscriber(new Listener\EventListener($this->coverage, $this->reportService));
+
+            foreach ($this->compilerPasses as $pass) {
+                $pass->process($this->container);
+            }
+
+
+        }else{
+
+            $this->container->get('event_dispatcher')->addSubscriber(new Listener\NoCoverage($this->container->get('cli.output')));
+
+        }
+
+    }
+
+}

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -8,11 +8,14 @@
 
 namespace LeanPHP\Behat\CodeCoverage;
 
+use Behat\Testwork\Cli\ServiceContainer\CliExtension;
 use Behat\Testwork\ServiceContainer\Extension as ExtensionInterface;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use LeanPHP\Behat\CodeCoverage\Compiler;
 
@@ -23,6 +26,10 @@ use LeanPHP\Behat\CodeCoverage\Compiler;
  */
 class Extension implements ExtensionInterface
 {
+    
+    const COVERAGE_CODE_COVERAGE = 'behat.code_coverage.php_code_coverage';
+    const COVERAGE_REPORT = 'behat.code_coverage.service.report';
+    
     /**
      * @var string
      */
@@ -50,6 +57,8 @@ class Extension implements ExtensionInterface
      */
     public function load(ContainerBuilder $container, array $config)
     {
+        $this->loadController($container);
+
         $loader = new XmlFileLoader($container, new FileLocator($this->configFolder));
 
         $servicesFile = 'services.xml';
@@ -205,11 +214,19 @@ class Extension implements ExtensionInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $passes = $this->getCompilerPasses();
+        //Controller handles the process.
+    }
 
-        foreach ($passes as $pass) {
-            $pass->process($container);
-        }
+    public function loadController(ContainerBuilder $container)
+    {
+        $definition = new Definition('\LeanPHP\Behat\CodeCoverage\CoverageController', array(
+            $container,
+            new Reference(self::COVERAGE_CODE_COVERAGE),
+            new Reference(self::COVERAGE_REPORT),
+            $this->getCompilerPasses()
+        ));
+        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 80000));
+        $container->setDefinition(CliExtension::CONTROLLER_TAG . '.coverage', $definition);
     }
 
     private function getCompilerPasses()

--- a/src/Listener/NoCoverage.php
+++ b/src/Listener/NoCoverage.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * No Coverage Event Listener
+ *
+ * @copyright 2018 Danny Lewis
+ * @license BSD-2-Clause
+ */
+
+namespace LeanPHP\Behat\CodeCoverage\Listener;
+
+use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * No Coverage
+ *
+ * @author Danny Lewis
+ */
+class NoCoverage implements EventSubscriberInterface
+{
+
+    private $output;
+
+    public function __construct(ConsoleOutput $output)
+    {
+        $this->output = $output;
+    }
+
+    public function showDisabledMessage(ExerciseCompleted $event)
+    {
+        $this->output->writeln('Code coverage is disabled, enable with "coverage" flag. e.g. bin/behat --coverage');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            ExerciseCompleted::BEFORE => array('showDisabledMessage', -10),
+            ExerciseCompleted::AFTER => array('showDisabledMessage', -10),
+        );
+    }
+
+
+}

--- a/src/Resources/config/services-2.3.xml
+++ b/src/Resources/config/services-2.3.xml
@@ -73,12 +73,6 @@
             <tag name="behat.code_coverage.driver" alias="remote" />
         </service>
 
-        <service id="behat.code_coverage.listener.event" class="%behat.code_coverage.listener.event.class%">
-            <argument type="service" id="behat.code_coverage.php_code_coverage" />
-            <argument type="service" id="behat.code_coverage.service.report" />
-            <tag name="event_dispatcher.subscriber" />
-        </service>
-
         <service id="behat.code_coverage.service.report_factory" class="%behat.code_coverage.service.report_factory.class%" />
 
         <service id="behat.code_coverage.service.report" class="%behat.code_coverage.service.report.class%">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -73,12 +73,6 @@
             <tag name="behat.code_coverage.driver" alias="remote" />
         </service>
 
-        <service id="behat.code_coverage.listener.event" class="%behat.code_coverage.listener.event.class%">
-            <argument type="service" id="behat.code_coverage.php_code_coverage" />
-            <argument type="service" id="behat.code_coverage.service.report" />
-            <tag name="event_dispatcher.subscriber" />
-        </service>
-
         <service id="behat.code_coverage.service.report_factory" class="%behat.code_coverage.service.report_factory.class%" />
 
         <service id="behat.code_coverage.service.report" class="%behat.code_coverage.service.report.class%">


### PR DESCRIPTION
Generating code coverage is slow so I've added flag --coverage to the command to generate reports if set, if it's not set it informs the user of how to set the flag. This is inline with the PHPUnit way of enabling coverage reports.