### PR TITLE
Fix text report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed a bug where a suffix when whitelisting files would default to `src`.
   This would make reports not generate in case no `suffix` was defined in
   configuration.
+- Fixed Text report printing (issue #12)
 - `phpunit/php-code-coverage` dependency version requirement has been updated
   from `~4.0|~5.0` to `~5.0` as we do not support version `4.0` anymore.
 - Updated README to list all configuration options

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,26 +1,12 @@
 default:
   extensions:
     LeanPHP\Behat\CodeCoverage\Extension:
-# optional authentication
-      drivers:
-        - local
       filter:
-        forceCoversAnnotation:                false
-        mapTestClassNameToCoveredClassName:   false
         whitelist:
-          addUncoveredFilesFromWhitelist:     true
-          processUncoveredFilesFromWhitelist: false
           include:
             directories:
               'src': ~
-#           files:
-#             - 'script.php'
-#         exclude:
-#           directories:
-#             'vendor': ~
-#           files:
-#             - src/script.php
       report:
-        format:    html
+        format: html
         options:
           target: build/coverage-behat

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -54,7 +54,7 @@ class ReportService
         $report = $this->factory->create($format, $options);
         $output = $report->process($coverage);
 
-        if ($format === 'text') {
+        if ('text' == $format) {
             print_r($output);
         }
     }

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -52,6 +52,10 @@ class ReportService
         $options = $this->config['report']['options'];
 
         $report = $this->factory->create($format, $options);
-        $report->process($coverage);
+        $output = $report->process($coverage);
+
+        if ($format === 'text') {
+            print_r($output);
+        }
     }
 }

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -54,7 +54,7 @@ class ReportService
         $report = $this->factory->create($format, $options);
         $output = $report->process($coverage);
 
-        if ('text' == $format) {
+        if ('text' === $format) {
             print_r($output);
         }
     }


### PR DESCRIPTION
Fix text report not being printed when `text` format was specified in the configuration.

Fixes #12 